### PR TITLE
update copyright notice

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-﻿Copyright (c) 2018 Frank Kicenko
+Copyright (c) 2018 Cisco Systems, Inc. and/or its affiliates
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 


### PR DESCRIPTION
Removed special character that was confusing GitHub license detection algorithm and added Cisco as copyright owner